### PR TITLE
Fix refreshing after points change

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -89,7 +89,7 @@ export namespace Conditions {
   }
 
   export function equals(a: Conditions, b: Conditions): boolean {
-    return a.gameType === b.gameType && a.back === b.back && a.fives === b.fives;
+    return a.gameType === b.gameType && a.back === b.back && a.fives === b.fives && a.points === b.points && a.dealType === b.dealType;
   }
 
   export function describe(ts: Conditions): string {


### PR DESCRIPTION
To reproduce:
1. Connect, take a seat
2. Set points to 40k, deal (might be unnecessary)
3. Set points to 100k, deal
4. Open a new window, connect The game crashed since it didn't see the change in conditions.

Thanks to Ryan Dirheimer for the report.